### PR TITLE
Change handling of gotify scheme

### DIFF
--- a/config/readConfig.go
+++ b/config/readConfig.go
@@ -44,7 +44,10 @@ func readConf() *Config {
 	// the scheme is replaced with the appropriate websocket scheme.
 	c.Gotify.URL = strings.ReplaceAll(c.Gotify.URL, "http://", "ws://")
 	c.Gotify.URL = strings.ReplaceAll(c.Gotify.URL, "https://", "wss://")
-
+	// set default wss scheme for backward compatibility
+	if !strings.HasPrefix(c.Gotify.URL, "ws") {
+		c.Gotify.URL = "wss://" + c.Gotify.URL
+	}
 	return c
 }
 

--- a/config/readConfig.go
+++ b/config/readConfig.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"log"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
@@ -39,9 +40,10 @@ func readConf() *Config {
 		c.Matrix.MatrixDomain = strings.ReplaceAll(c.Matrix.HomeServerURL, "https://", "")
 	}
 
-	// The gotify url should not contain a schema
-	c.Gotify.URL = strings.ReplaceAll(c.Gotify.URL, "http://", "")
-	c.Gotify.URL = strings.ReplaceAll(c.Gotify.URL, "https://", "")
+	// As the websocket connection for connecting to gotify is used,
+	// the scheme is replaced with the appropriate websocket scheme.
+	c.Gotify.URL = strings.ReplaceAll(c.Gotify.URL, "http://", "ws://")
+	c.Gotify.URL = strings.ReplaceAll(c.Gotify.URL, "https://", "wss://")
 
 	return c
 }

--- a/gotify_messages/websocket.go
+++ b/gotify_messages/websocket.go
@@ -1,27 +1,28 @@
 package gotify_messages
 
 import (
-	"github.com/gorilla/websocket"
 	"gotify_matrix_bot/config"
 	"log"
 	"net/url"
-)
 
-var websocketURL, urlError = url.Parse("wss://" + config.Configuration.Gotify.URL + "/stream?token=" + config.Configuration.Gotify.ApiToken)
+	"github.com/gorilla/websocket"
+)
 
 type callbackFunction func(string)
 
 func OnNewMessage(callback callbackFunction) {
 
+	websocketURL, urlError := url.Parse(config.Configuration.Gotify.URL + "/stream?token=" + config.Configuration.Gotify.ApiToken)
+
 	if urlError != nil {
-		log.Fatal("Error while trying to cast as url: ",
-			"wss://"+config.Configuration.Gotify.URL+"/stream?token="+config.Configuration.Gotify.ApiToken, " ",
+		log.Fatal("Error while trying to parse gotify url: ",
+			config.Configuration.Gotify.URL+"/stream?token="+config.Configuration.Gotify.ApiToken, " ",
 			urlError)
 	}
 
 	c, _, err := websocket.DefaultDialer.Dial(websocketURL.String(), nil)
 	if err != nil {
-		log.Fatal("Error while trying to connect to the webserver:", err)
+		log.Fatal("Error while trying to connect to the gotify server:", err)
 	}
 
 	done := make(chan struct{})
@@ -31,7 +32,7 @@ func OnNewMessage(callback callbackFunction) {
 		for {
 			_, message, err := c.ReadMessage()
 			if err != nil {
-				log.Fatal("The websocket connection returned an error. Error message: ", err)
+				log.Fatal("The websocket connection to gotify returned an error. Error message: ", err)
 			}
 
 			callback(string(message))


### PR DESCRIPTION
Dependent on the scheme of the configured gotify url, the websocket scheme is selected.
Should be backwards compatible and defaults to wss if no scheme is configured in url.

Fixes an issue, if gotify is hosted on non-tls connections.